### PR TITLE
[Improve] Field policy for local-only daysOfExperience field 

### DIFF
--- a/apollo/client.js
+++ b/apollo/client.js
@@ -44,6 +44,21 @@ function createApolloClient(initialState = null) {
             }
           }
         }
+      },
+      Portfolio: {
+        fields: {
+          daysOfExperience: {
+            read(_, { readField }) {
+              const startDate = readField('startDate');
+              const endDate = readField('endDate');
+              if (!startDate) return 'Invalid date';
+
+              let now = dayjs().valueOf();
+              if (endDate) now = dayjs(+endDate);
+              return dayjs(now).diff(dayjs(+startDate), 'day');
+            }
+          }
+        }
       }
     }
   });
@@ -55,16 +70,7 @@ function createApolloClient(initialState = null) {
       credentials: 'same-origin'
     }),
     cache: cache.restore(windowApolloState || initialState),
-    ssrForceFetchDelay: 100,
-    resolvers: {
-      Portfolio: {
-        daysOfExperience({ startDate, endDate }) {
-          let now = dayjs().valueOf();
-          if (endDate) now = dayjs(+endDate);
-          return dayjs(now).diff(dayjs(+startDate), 'day');
-        }
-      }
-    }
+    ssrForceFetchDelay: 100
   });
 }
 

--- a/constants/messages.js
+++ b/constants/messages.js
@@ -1,6 +1,6 @@
 export const messages = {
   NOT_AUTHENTICATED: {
-    value: 'Yoy need to log in to get an access',
+    value: 'You need to log in to get an access',
     status: 'danger'
   },
   NOT_AUTHORIZED: {


### PR DESCRIPTION
Removed local resolver because local resolver support will be moved out of the core of Apollo Client in a future.  